### PR TITLE
ヒント機能を追加 #20

### DIFF
--- a/SudokuSolver/View/MainBoardView.swift
+++ b/SudokuSolver/View/MainBoardView.swift
@@ -240,7 +240,8 @@ struct MainBoardView: View {
     // 全てのヒントを解除するボタン
     private var resetHintButton: some View {
         Button {
-            // TODO: 全てのヒントを解除する
+            // 全てのヒントを解除する
+            viewModel.resetAllHints()
         } label: {
             Text("Reset Hint")
                 .frame(width: 120, height: 32)

--- a/SudokuSolver/View/MainBoardView.swift
+++ b/SudokuSolver/View/MainBoardView.swift
@@ -105,7 +105,7 @@ struct MainBoardView: View {
                         Button {
                             // 選択されている数字を盤面に入力する
                             viewModel.enterNumberOnBoard(row: row, column: column)
-                            // ヒントボタンが選択されていたら、
+                            // ヒントが選択されている場合
                             if viewModel.selectedButton == .hint {
                                 viewModel.hintBoard[row][column].toggle()
                             } // if ここまで

--- a/SudokuSolver/View/MainBoardView.swift
+++ b/SudokuSolver/View/MainBoardView.swift
@@ -105,15 +105,21 @@ struct MainBoardView: View {
                         Button {
                             // 選択されている数字を盤面に入力する
                             viewModel.enterNumberOnBoard(row: row, column: column)
+                            // ヒントボタンが選択されていたら、
+                            if viewModel.selectedButton == .hint {
+                                viewModel.hintBoard[row][column].toggle()
+                            } // if ここまで
                         } label: {
                             // 0だったら表示しない
                             Text(number == 0 ? "" : String(number))
                                 .frame(width: 40, height: 40)
                                 .border(Color.black, width: 1)
-                            // 背景色を白とグレーに分ける
+                            // 背景色を指定
                                 .background(
                                     Group {
-                                        if (row / 3 != 1 && column / 3 != 1) || (row / 3 == 1 && column / 3 == 1) {
+                                        if viewModel.hintBoard[row][column] {
+                                            Color.buttonOrange
+                                        } else if (row / 3 != 1 && column / 3 != 1) || (row / 3 == 1 && column / 3 == 1) {
                                             Color.white
                                         } else {
                                             Color.boardGray
@@ -213,7 +219,7 @@ struct MainBoardView: View {
                 .cornerRadius(5)
                 .foregroundColor(Color.white)
                 .font(.title2)
-        } // Button ここまで
+        } // ShareLink ここまで
     } // shareButton ここまで
     
     // ヒントボタン

--- a/SudokuSolver/ViewModel/MainBoardViewModel.swift
+++ b/SudokuSolver/ViewModel/MainBoardViewModel.swift
@@ -113,4 +113,9 @@ class MainBoardViewModel {
     func cancelSolve() {
         sudokuSolver.cancelSolve()
     } // cancelSolve ここまで
+    
+    // 全てのヒントを解除するメソッド
+    func resetAllHints() {
+        hintBoard = Array(repeating: Array(repeating: false, count: 9), count: 9)
+    } // resetAllHints ここまで
 } // MainBoardViewModel

--- a/SudokuSolver/ViewModel/MainBoardViewModel.swift
+++ b/SudokuSolver/ViewModel/MainBoardViewModel.swift
@@ -94,7 +94,7 @@ class MainBoardViewModel {
                 for row in 0..<9 {
                     for column in 0..<9 {
                         // ヒントが指定されているセルについてのみ、解を表示
-                        if hintBoard[row][column] {
+                        if hintBoard[row][column] == true {
                             sudoku[row][column] = solution[row][column]
                         } // if ここまで
                     } // for ここまで

--- a/SudokuSolver/ViewModel/MainBoardViewModel.swift
+++ b/SudokuSolver/ViewModel/MainBoardViewModel.swift
@@ -89,7 +89,20 @@ class MainBoardViewModel {
         // 数独を解く
         if let solution = await sudokuSolver.solve() {
             pushSudokuIntoStack()
-            sudoku = solution
+            // 一つでもヒントが指定されていた場合
+            if hintBoard.flatMap({ $0 }).contains(true) {
+                for row in 0..<9 {
+                    for column in 0..<9 {
+                        // ヒントが指定されているセルについてのみ、解を表示
+                        if hintBoard[row][column] {
+                            sudoku[row][column] = solution[row][column]
+                        } // if ここまで
+                    } // for ここまで
+                } // for ここまで
+            } else {
+                // 一つもヒントが指定されてない場合、全ての解を表示
+                sudoku = solution
+            } // if ここまで
         } else {
             // キャンセルされた後、キャンセル状態をfalseに戻す
             sudokuSolver.resetCancel()

--- a/SudokuSolver/ViewModel/MainBoardViewModel.swift
+++ b/SudokuSolver/ViewModel/MainBoardViewModel.swift
@@ -23,10 +23,12 @@ class MainBoardViewModel {
                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0]]
-    // Undoのための履歴を保持する変数
-    private var sudokuStack: [[[Int]]] = []
+    // ヒントを管理する変数
+    var hintBoard: [[Bool]] = Array(repeating: Array(repeating: false, count: 9), count: 9)
     // 数独が初期条件を満たさない時の警告の表示を管理する変数
     var isShowInvalidAlert: Bool = false
+    // Undoのための履歴を保持する変数
+    private var sudokuStack: [[[Int]]] = []
     // 空の数独
     private let emptySudoku = [[0, 0, 0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -39,7 +41,7 @@ class MainBoardViewModel {
                                [0, 0, 0, 0, 0, 0, 0, 0, 0]]
     // 数独ソルバーのインスタンスを生成
     private let sudokuSolver: SudokuSolver = SudokuSolver()
-
+    
     // 数独の盤面に数字を入力するメソッド
     func enterNumberOnBoard(row: Int, column: Int) {
         // ボタンタイプの数値を取得


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #20 

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
ヒントを出す機能
Hintボタンについて

Hintボタンを選択した状態で盤面のマスをタップすると、ますがオレンジ色になるようにします（複数可）。
オレンジ色になっているセルを再びタップすると下の色に戻り、Hint状態が解除されるようにします。
その状態でsolveを押すとオレンジ色になったセルのみ数独の解が表示されるようにします。
Reset Hintボタンについて
Reset Hintボタンを押すと、全てのヒント状態が解除され、オレンジ色のセルがなくなるようにします。

<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
ユーザーにヒントを提供する機能を追加するため。

<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
- [x] Hintボタンを選択した状態で盤面のセルをタップすると、セルがオレンジ色になるようにします（複数可）。
- [x] オレンジ色になっているセルを再びタップするともとの色に戻り、Hint状態が解除されるようにします。
- [x] その状態でsolveを押すとオレンジ色になったセルのみ数独の解が表示されるようにします。
- [x] Reset Hintボタンを押すと、全てのヒント状態が解除され、オレンジ色のセルがなくなるようにします。

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
- MainBoardViewModelにヒントを管理する変数```hintBoard```を作成しました。
- ヒントボタンが選択されていたら、セルがタップされた時に、セルをオレンジ色にする処理をMainBoardViewの```board```プロパティのButtonのaction部分に追加しました。
- オレンジ色になっているセルが一つでもある状態でSolveボタンを押した場合、オレンジ色になっているセルにのみ解を表示するような処理を、MainBoardVIewModelの```solveSudoku```メソッドに追加しました。
- 全てのヒントの指定を解除する```resetAllHints```メソッドを作成し、Reset Hintボタンが押されたら発火するようにしました。

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
- MainBoardView
- MainBoardViewModel

<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
1. 任意の数独を盤面上に入力してください。
2. Hintボタンを選択した状態で盤面の空のセルをタップし、セルがオレンジ色になることを確認してください。
3. オレンジ色になっているセルを再びタップするともとの色に戻り、Hint状態が解除されることを確認してください。
4. オレンジ色のセルが一つでもある状態でsolveを押すとオレンジ色になったセルのみ数独の解が表示されることを確認してください。
5. Reset Hintボタンを押すと、全てのヒント状態が解除され、オレンジ色のセルがなくなることを確認してください。

<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
上記の項目を確認しました。

<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
特になし。