### PR TITLE
フォトライブラリーからの画像の取得機能を追加 #25

### DIFF
--- a/SudokuSolver.xcodeproj/project.pbxproj
+++ b/SudokuSolver.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		4A72277D2B92E23B009E8C28 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A72277C2B92E23B009E8C28 /* Preview Assets.xcassets */; };
 		4A72277F2B92E23B009E8C28 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A72277E2B92E23B009E8C28 /* Persistence.swift */; };
 		4A7227822B92E23B009E8C28 /* SudokuSolver.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4A7227802B92E23B009E8C28 /* SudokuSolver.xcdatamodeld */; };
+		4A9C37492B9C486B00EC5439 /* ScanSudokuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C37482B9C486B00EC5439 /* ScanSudokuViewModel.swift */; };
 		4AB912672B975DE90093D7B2 /* SudokuSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB912662B975DE90093D7B2 /* SudokuSolver.swift */; };
 		4AF7B91E2B9490FF007619EA /* MainBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -31,6 +32,7 @@
 		4A72277C2B92E23B009E8C28 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		4A72277E2B92E23B009E8C28 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		4A7227812B92E23B009E8C28 /* SudokuSolver.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SudokuSolver.xcdatamodel; sourceTree = "<group>"; };
+		4A9C37482B9C486B00EC5439 /* ScanSudokuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanSudokuViewModel.swift; sourceTree = "<group>"; };
 		4AB912662B975DE90093D7B2 /* SudokuSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuSolver.swift; sourceTree = "<group>"; };
 		4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainBoardViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -108,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */,
+				4A9C37482B9C486B00EC5439 /* ScanSudokuViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 			files = (
 				4A3BA95B2B934BCB00A9A5A6 /* ButtonType.swift in Sources */,
 				4A3BA95F2B935D4F00A9A5A6 /* SudokuListView.swift in Sources */,
+				4A9C37492B9C486B00EC5439 /* ScanSudokuViewModel.swift in Sources */,
 				4AB912672B975DE90093D7B2 /* SudokuSolver.swift in Sources */,
 				4A72277F2B92E23B009E8C28 /* Persistence.swift in Sources */,
 				4A3BA9592B93427900A9A5A6 /* MainBoardView.swift in Sources */,

--- a/SudokuSolver/View/MainBoardView.swift
+++ b/SudokuSolver/View/MainBoardView.swift
@@ -133,7 +133,6 @@ struct MainBoardView: View {
                 } // HStack ここまで
             } // ForEach ここまで
         } // VStack ここまで
-        .padding()
     } // board ここまで
     
     // 数字ボタン

--- a/SudokuSolver/View/ScanSudokuView.swift
+++ b/SudokuSolver/View/ScanSudokuView.swift
@@ -6,16 +6,30 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct ScanSudokuView: View {
+    // ScanSudokuViewModelのインスタンス
+    @State private var viewModel: ScanSudokuViewModel = ScanSudokuViewModel()
     
     var body: some View {
         VStack {
             Spacer()
-            Rectangle()
-                .fill(Color.clear)
-                .stroke(Color.blue, lineWidth: 2)
-                .frame(width: 280, height: 280)
+            ZStack {
+                if let image = viewModel.image {
+                    Image(uiImage: image)
+                    // 画像のリサイズ
+                        .resizable()
+                    // 横幅
+                        .scaledToFit()
+                    // 幅高さ280に指定
+                        .frame(width: 280, height: 280)
+                } // 画像を表示
+                Rectangle()
+                    .fill(Color.clear)
+                    .stroke(Color.blue, lineWidth: 2)
+                    .frame(width: 280, height: 280)
+            } // ZStack ここまで
             Spacer()
             // カメラ表示ボタン
             Button {
@@ -30,9 +44,7 @@ struct ScanSudokuView: View {
                     .padding()
             } // Button ここまで
             // フォトライブラリー表示ボタン
-            Button {
-                // TODO: フォトライブラリーを表示
-            } label: {
+            PhotosPicker(selection: $viewModel.selectedPhoto) {
                 Text("Photo Library")
                     .frame(maxWidth: .infinity)
                     .frame(height: 50)
@@ -41,6 +53,12 @@ struct ScanSudokuView: View {
                     .foregroundColor(Color.white)
                     .padding()
             } // Button ここまで
+            .onChange(of: viewModel.selectedPhoto) {
+                Task {
+                    // UIImageを取得
+                    await viewModel.getUIImage()
+                } // Task ここまで
+            } // onChange ここまで
         } // VStack ここまで
     } // body ここまで
 } // ScanSudokuView ここまで

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  ScanSudokuViewModel.swift
+//  SudokuSolver
+//
+//  Created by 寒河江彪流 on 2024/03/09.
+//
+
+import SwiftUI
+import PhotosUI
+
+@Observable
+final class ScanSudokuViewModel {
+    // 選択された写真を保持する変数
+    var selectedPhoto: PhotosPickerItem? = nil
+    // 取得したUIImageを保持する変数
+    var image: UIImage? = nil
+    
+    @MainActor
+    // PhotosPickerItemをUIImageに変換
+    func getUIImage() async {
+        if let selectedPhoto {
+            do {
+                guard let data = try await selectedPhoto.loadTransferable(type: Data.self) else { return }
+                guard let uiImage = UIImage(data: data) else { return }
+                image = uiImage
+            } catch {
+                print("PhotosPickerでエラーが発生しました: \(error)")
+            } // do-try-catch ここまで
+        } // if let ここまで
+    } // getUIImage ここまで
+} // ScanSudokuViewModel ここまで


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Issue番号
close #25

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
フォトライブラリーからの画像の取得機能

<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
フォトライブラリーから数独の画像を読み込めるようにするため。

<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
- [x] ScanSudokuViewで、Photo Libraryボタンを押して、フォトライブラリーから画像を取得する。
- [x] 取得した画像をScanSudokuViewに表示する。

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
- ScanSudokuViewのフォトライブラリー表示ボタンとしてPhotoPickerを使用するように変更しました。
- PhotoPickerで取得した画像をScanSudokuViewのRectangle部分にZStackで重ねて表示するようにしました。

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
- ScanSudokuView
- ScanSudokuViewModel

<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
1. MainBoardViewのカメラのマークのボタンをタップしてScanSudokuView画面に移動してください。
2. Photo Libraryボタンをタップして、任意の画像を選択してください。
3. 選択した画像が表示されることを確認してください。

<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
上のことを確認しました。

<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
特になし。