### PR TITLE
シェアボタンをタップしても現在の盤面が適切に画像化されない #28

### DIFF
--- a/SudokuSolver.xcodeproj/project.pbxproj
+++ b/SudokuSolver.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4A72277F2B92E23B009E8C28 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A72277E2B92E23B009E8C28 /* Persistence.swift */; };
 		4A7227822B92E23B009E8C28 /* SudokuSolver.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4A7227802B92E23B009E8C28 /* SudokuSolver.xcdatamodeld */; };
 		4A9C37492B9C486B00EC5439 /* ScanSudokuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C37482B9C486B00EC5439 /* ScanSudokuViewModel.swift */; };
+		4A9C374B2B9CA08400EC5439 /* SudokuBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C374A2B9CA08400EC5439 /* SudokuBoardView.swift */; };
 		4AB912672B975DE90093D7B2 /* SudokuSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB912662B975DE90093D7B2 /* SudokuSolver.swift */; };
 		4AF7B91E2B9490FF007619EA /* MainBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -33,6 +34,7 @@
 		4A72277E2B92E23B009E8C28 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		4A7227812B92E23B009E8C28 /* SudokuSolver.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SudokuSolver.xcdatamodel; sourceTree = "<group>"; };
 		4A9C37482B9C486B00EC5439 /* ScanSudokuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanSudokuViewModel.swift; sourceTree = "<group>"; };
+		4A9C374A2B9CA08400EC5439 /* SudokuBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuBoardView.swift; sourceTree = "<group>"; };
 		4AB912662B975DE90093D7B2 /* SudokuSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuSolver.swift; sourceTree = "<group>"; };
 		4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainBoardViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -63,6 +65,7 @@
 				4A3BA9582B93427900A9A5A6 /* MainBoardView.swift */,
 				4A3BA95E2B935D4E00A9A5A6 /* SudokuListView.swift */,
 				4A3BA9602B94269C00A9A5A6 /* ScanSudokuView.swift */,
+				4A9C374A2B9CA08400EC5439 /* SudokuBoardView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -210,6 +213,7 @@
 				4A3BA95B2B934BCB00A9A5A6 /* ButtonType.swift in Sources */,
 				4A3BA95F2B935D4F00A9A5A6 /* SudokuListView.swift in Sources */,
 				4A9C37492B9C486B00EC5439 /* ScanSudokuViewModel.swift in Sources */,
+				4A9C374B2B9CA08400EC5439 /* SudokuBoardView.swift in Sources */,
 				4AB912672B975DE90093D7B2 /* SudokuSolver.swift in Sources */,
 				4A72277F2B92E23B009E8C28 /* Persistence.swift in Sources */,
 				4A3BA9592B93427900A9A5A6 /* MainBoardView.swift in Sources */,

--- a/SudokuSolver/View/MainBoardView.swift
+++ b/SudokuSolver/View/MainBoardView.swift
@@ -126,7 +126,7 @@ struct MainBoardView: View {
                                         } // if ここまで
                                     } // Group ここまで
                                 ) // background ここまで
-                                .foregroundColor(Color.black)
+                                .foregroundStyle(Color.black)
                                 .font(.title)
                         } // Button ここまで
                     } // ForEach ここまで
@@ -205,7 +205,7 @@ struct MainBoardView: View {
     @ViewBuilder
     @MainActor
     private var shareButton: some View {
-        let sudokuImage = ImageRenderer(content: board).uiImage ?? UIImage()
+        let sudokuImage = viewModel.getSudokuImage()
         ShareLink(
             item: Image(uiImage: sudokuImage),
             subject: nil,

--- a/SudokuSolver/View/SudokuBoardView.swift
+++ b/SudokuSolver/View/SudokuBoardView.swift
@@ -1,0 +1,46 @@
+//
+//  SudokuBoardView.swift
+//  SudokuSolver
+//
+//  Created by 寒河江彪流 on 2024/03/09.
+//
+
+import SwiftUI
+
+struct SudokuBoardView: View {
+    // 数独の盤面
+    let board: [[Int]]
+    
+    var body: some View {
+        VStack(spacing: -1) {
+            ForEach(0..<9, id: \.self) { row in
+                HStack(spacing: -1) {
+                    ForEach(0..<9, id: \.self) { column in
+                        let number = board[row][column]
+                        Text(number == 0 ? "" : String(number))
+                            .frame(width: 40, height: 40)
+                            .border(Color.black, width: 1)
+                            .background(
+                                Group {
+                                    if (row / 3 != 1 && column / 3 != 1) || (row / 3 == 1 && column / 3 == 1) {
+                                        Color.white
+                                    } else {
+                                        Color.boardGray
+                                    } // if ここまで
+                                } // Group ここまで
+                            ) // background ここまで
+                            .foregroundStyle(Color.black)
+                            .font(.title)
+                    } // ForEach ここまで
+                } // HStack ここまで
+            } // ForEach ここまで
+        } // VStack
+    } // VStack
+    
+    // Viewをレンダリングするメソッド
+    @MainActor
+    func render() -> UIImage? {
+        let renderer = ImageRenderer(content: body)
+        return renderer.uiImage
+    } // render ここまで
+} // SudokuBoardView ここまで

--- a/SudokuSolver/ViewModel/MainBoardViewModel.swift
+++ b/SudokuSolver/ViewModel/MainBoardViewModel.swift
@@ -5,10 +5,10 @@
 //  Created by 寒河江彪流 on 2024/03/03.
 //
 
-import Foundation
+import SwiftUI
 
 @Observable
-class MainBoardViewModel {
+final class MainBoardViewModel {
     // 選択されているボタンを管理する変数
     var selectedButton: ButtonType = .start
     // 処理中であるかどうかを管理する変数
@@ -168,4 +168,18 @@ class MainBoardViewModel {
         } // for ここまで
         return true
     } // isValidInitially ここまで
+    
+    // 数独の盤面を画像に変換するメソッド
+    @MainActor
+    func getSudokuImage() -> UIImage {
+        // 数独の盤面のViewを生成
+        let sudokuBoardView = SudokuBoardView(board: sudoku)
+        // Viewを画像にレンダリング
+        if let image = sudokuBoardView.render() {
+            // 画像を生成できたら、生成した画像を返却
+            return image
+        } // if letここまで
+        // 画像を生成できなかったら、空の画像を返却
+        return UIImage()
+    } // getSudokuImage ここまで
 } // MainBoardViewModel


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #28

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
シェアボタンをタップしても現在の盤面が適切に画像化されない問題を解決します。

<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
現在の盤面が適切に画像化されるようにするため。

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
- 数独の盤面の画像化用のSudokuBoardViewを作成しました。
- MainBoardViewModelに数独の盤面を画像に変換するメソッド```getSudokuImage```を追加しました。

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
- SudokuBoardView
- SudokuBoardViewModel

<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
1. Listから数独を読み込むか、任意の数字を選択した状態で盤面をタップして、数字を入力します。
2. Shareボタンをタップし、メモ帳などのアプリに画像を送ります。
3. 送られた画像が現在の盤面の状態になっていることを確認してください。

<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
上記の内容を確認しました。

<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
特になし。