### PR TITLE
画像から数独を読み込むための前処理の機能を追加 #35

### DIFF
--- a/SudokuSolver.xcodeproj/project.pbxproj
+++ b/SudokuSolver.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4A9C374F2B9CB2E800EC5439 /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C374E2B9CB2E800EC5439 /* ImagePickerView.swift */; };
 		4A9C37552B9D64E400EC5439 /* DragAndPinchImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C37542B9D64E400EC5439 /* DragAndPinchImage.swift */; };
 		4A9C37592B9D896900EC5439 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C37582B9D896900EC5439 /* UIViewExtension.swift */; };
+		4A9C375B2B9DB87800EC5439 /* ImagePreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C375A2B9DB87700EC5439 /* ImagePreprocessor.swift */; };
 		4AB912672B975DE90093D7B2 /* SudokuSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB912662B975DE90093D7B2 /* SudokuSolver.swift */; };
 		4AF7B91E2B9490FF007619EA /* MainBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -41,6 +42,7 @@
 		4A9C374E2B9CB2E800EC5439 /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
 		4A9C37542B9D64E400EC5439 /* DragAndPinchImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragAndPinchImage.swift; sourceTree = "<group>"; };
 		4A9C37582B9D896900EC5439 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
+		4A9C375A2B9DB87700EC5439 /* ImagePreprocessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreprocessor.swift; sourceTree = "<group>"; };
 		4AB912662B975DE90093D7B2 /* SudokuSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SudokuSolver.swift; sourceTree = "<group>"; };
 		4AF7B91D2B9490FF007619EA /* MainBoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainBoardViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -61,6 +63,7 @@
 			children = (
 				4A3BA95A2B934BCB00A9A5A6 /* ButtonType.swift */,
 				4AB912662B975DE90093D7B2 /* SudokuSolver.swift */,
+				4A9C375A2B9DB87700EC5439 /* ImagePreprocessor.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -227,6 +230,7 @@
 				4A9C374F2B9CB2E800EC5439 /* ImagePickerView.swift in Sources */,
 				4AB912672B975DE90093D7B2 /* SudokuSolver.swift in Sources */,
 				4A72277F2B92E23B009E8C28 /* Persistence.swift in Sources */,
+				4A9C375B2B9DB87800EC5439 /* ImagePreprocessor.swift in Sources */,
 				4A3BA9592B93427900A9A5A6 /* MainBoardView.swift in Sources */,
 				4AF7B91E2B9490FF007619EA /* MainBoardViewModel.swift in Sources */,
 				4A7227762B92E238009E8C28 /* SudokuSolverApp.swift in Sources */,

--- a/SudokuSolver/Model/ImagePreprocessor.swift
+++ b/SudokuSolver/Model/ImagePreprocessor.swift
@@ -1,0 +1,45 @@
+//
+//  ImagePreprocessor.swift
+//  SudokuSolver
+//
+//  Created by 寒河江彪流 on 2024/03/10.
+//
+
+import UIKit
+
+final class ImagePreprocessor {
+    // 処理前の画像
+    let image: UIImage
+    
+    init(image: UIImage) {
+        self.image = image
+    } // init ここまで
+    
+    // 前処理するメソッド
+    func preprocess() -> [UIImage] {
+        getEachCell(from: image)
+    } // preprocess ここまで
+    
+    // 数独の画像の各セルを取得
+    private func getEachCell(from image: UIImage) -> [UIImage] {
+        // 枠をどの程度除外するかの基準
+        // 枠が含まれていると文字認識に影響が出てしまうので、画像から除外する
+        let criterion: CGFloat = CGFloat(0.15)
+        // セルの幅を取得
+        let cellWidth: CGFloat = image.size.width / CGFloat(4.5)
+        // セルの画像を格納する配列
+        var cellImages: [UIImage] = []
+        // 各セルからUIImageを取得
+        for row in 0..<9 {
+            for column in 0..<9 {
+                let cellRect = CGRect(x: cellWidth * (CGFloat(Double(column) + criterion)),
+                                      y: cellWidth * (CGFloat(Double(row) + criterion)),
+                                      width: cellWidth * CGFloat(1.0 - 2 * criterion),
+                                      height: cellWidth * CGFloat(1.0 - 2 * criterion))
+                guard let cellImage = image.cgImage?.cropping(to: cellRect) else { return [] }
+                cellImages.append(UIImage(cgImage: cellImage))
+            } // for ここまで
+        } // for ここまで
+        return cellImages
+    } // getEachCell ここまで
+} // ImagePreprocessor ここまで

--- a/SudokuSolver/Model/ImagePreprocessor.swift
+++ b/SudokuSolver/Model/ImagePreprocessor.swift
@@ -17,10 +17,14 @@ final class ImagePreprocessor {
     
     // 前処理するメソッド
     func preprocess() -> [UIImage] {
-        getEachCell(from: image)
+        // 数独の画像の各セルを取得
+        let cellImages = getEachCell(from: image)
+        // 画像を28x28ピクセルにリサイズ
+        let resizedImages = resizeTo28x28(images: cellImages)
+        return resizedImages
     } // preprocess ここまで
     
-    // 数独の画像の各セルを取得
+    // 数独の画像の各セルを取得するメソッド
     private func getEachCell(from image: UIImage) -> [UIImage] {
         // 枠をどの程度除外するかの基準
         // 枠が含まれていると文字認識に影響が出てしまうので、画像から除外する
@@ -42,4 +46,25 @@ final class ImagePreprocessor {
         } // for ここまで
         return cellImages
     } // getEachCell ここまで
+    
+    // 画像を28x28ピクセルにリサイズするメソッド
+    private func resizeTo28x28(images: [UIImage]) -> [UIImage] {
+        // 目標のピクセルサイズ（28）
+        let targetSize = CGSize(width: 28, height: 28)
+        // 新しい描画コンテキストのサイズ（リサイズ後の画像のサイズ）を指定
+        UIGraphicsBeginImageContextWithOptions(targetSize, false, UIScreen.main.scale)
+        let resizedImages = images.map { image in
+            // 指定したrect内に元の画像が収まるように縮小
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+            // リサイズされた画像を取得
+            if let image = UIGraphicsGetImageFromCurrentImageContext() {
+                return image
+            } else {
+                return UIImage()
+            } // if let ここまで
+        } // resizedImages ここまで
+        // 描画コンテキストをクリアして解放する（描画コンテキストをメモリ内から解放し、リソースのリークを防ぐため）
+        UIGraphicsEndImageContext()
+        return resizedImages
+    } // resizeImages ここまで
 } // ImagePreprocessor ここまで

--- a/SudokuSolver/Model/ImagePreprocessor.swift
+++ b/SudokuSolver/Model/ImagePreprocessor.swift
@@ -8,15 +8,8 @@
 import UIKit
 
 final class ImagePreprocessor {
-    // 処理前の画像
-    let image: UIImage
-    
-    init(image: UIImage) {
-        self.image = image
-    } // init ここまで
-    
     // 前処理するメソッド
-    func preprocess() -> [UIImage] {
+    static func preprocess(image: UIImage) -> [UIImage] {
         // 数独の画像の各セルを取得
         let cellImages = getEachCell(from: image)
         // 画像を28x28ピクセルにリサイズ
@@ -28,7 +21,7 @@ final class ImagePreprocessor {
     } // preprocess ここまで
     
     // 数独の画像の各セルを取得するメソッド
-    private func getEachCell(from image: UIImage) -> [UIImage] {
+    static private func getEachCell(from image: UIImage) -> [UIImage] {
         // 枠をどの程度除外するかの基準
         // 枠が含まれていると文字認識に影響が出てしまうので、画像から除外する
         let criterion: CGFloat = CGFloat(0.15)
@@ -51,7 +44,7 @@ final class ImagePreprocessor {
     } // getEachCell ここまで
     
     // 画像を28x28ピクセルにリサイズするメソッド
-    private func resizeTo28x28(images: [UIImage]) -> [UIImage] {
+    static private func resizeTo28x28(images: [UIImage]) -> [UIImage] {
         // 目標のピクセルサイズ（28）
         let targetSize = CGSize(width: 28, height: 28)
         // 新しい描画コンテキストのサイズ（リサイズ後の画像のサイズ）を指定
@@ -72,7 +65,7 @@ final class ImagePreprocessor {
     } // resizeImages ここまで
     
     // 画像をグレースケールに変換するメソッド
-    private func convertToGrayScale(images: [UIImage]) -> [UIImage] {
+    static private func convertToGrayScale(images: [UIImage]) -> [UIImage] {
         images.map { image in
             // UIImageをCIImageに変換
             let ciImage = CIImage(image: image)
@@ -92,7 +85,7 @@ final class ImagePreprocessor {
     } // convertToGrayScale ここまで
     
     // 白黒反転するメソッド
-    private func invertColor(images: [UIImage]) -> [UIImage] {
+    static private func invertColor(images: [UIImage]) -> [UIImage] {
         images.map { image in
             // cgImageを取得
             guard let cgImage = image.cgImage else { return UIImage() }

--- a/SudokuSolver/Model/ImagePreprocessor.swift
+++ b/SudokuSolver/Model/ImagePreprocessor.swift
@@ -21,7 +21,9 @@ final class ImagePreprocessor {
         let cellImages = getEachCell(from: image)
         // 画像を28x28ピクセルにリサイズ
         let resizedImages = resizeTo28x28(images: cellImages)
-        return resizedImages
+        // 画像をグレースケールに変換
+        let grayScaledImages = convertToGrayScale(images: resizedImages)
+        return grayScaledImages
     } // preprocess ここまで
     
     // 数独の画像の各セルを取得するメソッド
@@ -67,4 +69,24 @@ final class ImagePreprocessor {
         UIGraphicsEndImageContext()
         return resizedImages
     } // resizeImages ここまで
+    
+    // 画像をグレースケールに変換するメソッド
+    private func convertToGrayScale(images: [UIImage]) -> [UIImage] {
+        images.map { image in
+            // UIImageをCIImageに変換
+            let ciImage = CIImage(image: image)
+            // グレースケールにするためのフィルターを作成
+            guard let filter = CIFilter(name: "CIColorControls") else { return UIImage() }
+            // フィルターに画像をセット
+            filter.setValue(ciImage, forKey: kCIInputImageKey)
+            // 彩度を完全に除去し、画像をグレースケールに変換
+            filter.setValue(0.0, forKey: kCIInputSaturationKey)
+            // フィルターをした画像を取得
+            guard let outputImage = filter.outputImage else { return UIImage() }
+            // cgImageを取得
+            guard let cgImage = CIContext().createCGImage(outputImage, from: outputImage.extent) else { return UIImage() }
+            // cgImageをUIImageに変換して返却
+            return UIImage(cgImage: cgImage)
+        } // map ここまで
+    } // convertToGrayScale ここまで
 } // ImagePreprocessor ここまで

--- a/SudokuSolver/View/MainBoardView.swift
+++ b/SudokuSolver/View/MainBoardView.swift
@@ -14,7 +14,6 @@ struct MainBoardView: View {
     @State private var isShowList: Bool = false
     // 数独を保存したことを伝えるメッセージの表示を管理すつ変数
     @State private var isShowSaveMessage: Bool = false
-    
     // ViewModel
     @State private var viewModel: MainBoardViewModel = MainBoardViewModel()
     

--- a/SudokuSolver/View/ScanSudokuView.swift
+++ b/SudokuSolver/View/ScanSudokuView.swift
@@ -15,75 +15,82 @@ struct ScanSudokuView: View {
     // カメラの表示を管理する変数
     @State private var isShowCamera: Bool = false
     
+    // 画像チェック用シートを管理する変数
+    @State private var isShowSheet: Bool = false
+    
     var body: some View {
-        ZStack {
-            VStack {
-                Spacer()
-                Group {
-                    GeometryReader { geometry in
-                        if let image = viewModel.image {
-                            // 画像を表示
-                            DragAndPinchImage(image: image)
-                            // 画像が表示された時にフレームの座標とサイズを取得
-                                .onAppear {
-                                    viewModel.frameRect = geometry.frame(in: .global)
-                                } // onAppear ここまで
-                        } // if let ここまで
-                    } // GeometryReader ここまで
-                } // Group ここまで
-                .frame(width: 280, height: 280)
-                .border(Color.blue, width: 2)
-                Spacer()
-                // カメラ表示ボタン
-                Button {
-                    // カメラを表示
-                    isShowCamera.toggle()
-                } label: {
-                    Text("Camera")
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(Color.buttonBlue)
-                        .cornerRadius(5)
-                        .foregroundStyle(Color.white)
-                } // Button ここまで
-                .sheet(isPresented: $isShowCamera) {
-                    ImagePickerView(viewModel: $viewModel)
-                } // sheet ここまで
-                // フォトライブラリー表示ボタン
-                PhotosPicker(selection: $viewModel.selectedPhoto) {
-                    Text("Photo Library")
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(Color.buttonBlue)
-                        .cornerRadius(5)
-                        .foregroundStyle(Color.white)
-                } // Button ここまで
-                .onChange(of: viewModel.selectedPhoto) {
-                    Task {
-                        // UIImageを取得
-                        await viewModel.getUIImage()
-                    } // Task ここまで
-                } // onChange ここまで
-                // 数独読み込みボタン
-                Button {
-                    // 枠内を画像化
-                    viewModel.getImageInsideFrame()
-                } label: {
-                    Text("Load Sudoku")
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(viewModel.image == nil ? Color.gray : Color.buttonBlue)
-                        .cornerRadius(5)
-                        .foregroundStyle(Color.white)
-                } // Button ここまで
-                // 画像が読み込まれていないときはボタンを押せなくする
-                .disabled(viewModel.image == nil)
-            } // VStack ここまで
-            .padding()
-            if let imageInsideFrame = viewModel.imageInsideFrame {
-                Image(uiImage: imageInsideFrame)
-            } // if let ここまで
-        } // ZStack ここまで
+        VStack {
+            Spacer()
+            Group {
+                GeometryReader { geometry in
+                    if let image = viewModel.image {
+                        // 画像を表示
+                        DragAndPinchImage(image: image)
+                        // 画像が表示された時にフレームの座標とサイズを取得
+                            .onAppear {
+                                viewModel.frameRect = geometry.frame(in: .global)
+                            } // onAppear ここまで
+                    } // if let ここまで
+                } // GeometryReader ここまで
+            } // Group ここまで
+            .frame(width: 280, height: 280)
+            .border(Color.blue, width: 2)
+            Spacer()
+            // カメラ表示ボタン
+            Button {
+                // カメラを表示
+                isShowCamera.toggle()
+            } label: {
+                Text("Camera")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.buttonBlue)
+                    .cornerRadius(5)
+                    .foregroundStyle(Color.white)
+            } // Button ここまで
+            .sheet(isPresented: $isShowCamera) {
+                ImagePickerView(viewModel: $viewModel)
+            } // sheet ここまで
+            // フォトライブラリー表示ボタン
+            PhotosPicker(selection: $viewModel.selectedPhoto) {
+                Text("Photo Library")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.buttonBlue)
+                    .cornerRadius(5)
+                    .foregroundStyle(Color.white)
+            } // Button ここまで
+            .onChange(of: viewModel.selectedPhoto) {
+                Task {
+                    // UIImageを取得
+                    await viewModel.getUIImage()
+                } // Task ここまで
+            } // onChange ここまで
+            // 数独読み込みボタン
+            Button {
+                // 数独を読み込み
+                viewModel.loadSudoku()
+                isShowSheet.toggle()
+            } label: {
+                Text("Load Sudoku")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(viewModel.image == nil ? Color.gray : Color.buttonBlue)
+                    .cornerRadius(5)
+                    .foregroundStyle(Color.white)
+            } // Button ここまで
+            // 画像が読み込まれていないときはボタンを押せなくする
+            .disabled(viewModel.image == nil)
+            // 画像確認用(後で消す)
+            .sheet(isPresented: $isShowSheet) {
+                List {
+                    ForEach(viewModel.images, id: \.self) { image in
+                        Image(uiImage: image)
+                    } // ForEach ここまで
+                } // List ここまで
+            } // sheet ここまで
+        } // VStack ここまで
+        .padding()
     } // body ここまで
 } // ScanSudokuView ここまで
 

--- a/SudokuSolver/View/ScanSudokuView.swift
+++ b/SudokuSolver/View/ScanSudokuView.swift
@@ -91,6 +91,10 @@ struct ScanSudokuView: View {
             } // sheet ここまで
         } // VStack ここまで
         .padding()
+        // このViewが閉じたとき、プロパティを初期化
+        .onDisappear {
+            viewModel.initializeProperties()
+        } // onDisappear ここまで
     } // body ここまで
 } // ScanSudokuView ここまで
 

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -19,6 +19,18 @@ final class ScanSudokuViewModel {
     // 各セルのImageを保持する配列
     var images: [UIImage] = []
     
+    // 枠内の画像を取得
+    private var imageInsideFrame: UIImage {
+        // アプリケーションの最初のシーンを取得し、それがUIWindowSceneであることを確認
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return UIImage() }
+        // 取得したウィンドウシーンから、最初のウィンドウを取得
+        guard let mainWindow = windowScene.windows.first else { return UIImage() }
+        // ウィンドウのルートビューコントローラーのビューから、指定された枠内の画像を取得
+        guard let image = mainWindow.rootViewController?.view.getImage(rect: frameRect) else { return UIImage() }
+        // 取得した画像を保持
+        return image
+    } // getImageInsideFrame ここまで
+    
     @MainActor
     // PhotosPickerItemをUIImageに変換
     func getUIImage() async {
@@ -36,20 +48,8 @@ final class ScanSudokuViewModel {
     // 画像から数独を読み込むメソッド
     func loadSudoku() {
         // 画像の前処理を実行
-        images = ImagePreprocessor.preprocess(image: getImageInsideFrame())
+        images = ImagePreprocessor.preprocess(image: imageInsideFrame)
     } // loadSudoku ここまで
-
-    // 枠内の画像を取得するメソッド
-    private func getImageInsideFrame() -> UIImage {
-        // アプリケーションの最初のシーンを取得し、それがUIWindowSceneであることを確認
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return UIImage() }
-        // 取得したウィンドウシーンから、最初のウィンドウを取得
-        guard let mainWindow = windowScene.windows.first else { return UIImage() }
-        // ウィンドウのルートビューコントローラーのビューから、指定された枠内の画像を取得
-        guard let image = mainWindow.rootViewController?.view.getImage(rect: frameRect) else { return UIImage() }
-        // 取得した画像を保持
-        return image
-    } // getImageInsideFrame ここまで
     
     // プロパティの状態を初期値に戻すメソッド
     func initializeProperties() {

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -35,12 +35,8 @@ final class ScanSudokuViewModel {
     
     // 画像から数独を読み込むメソッド
     func loadSudoku() {
-        // 枠内の画像を取得
-        let imageInsideFrame = getImageInsideFrame()
-        // ImagePreprocessorのインスタンスを生成
-        let preprocessor = ImagePreprocessor(image: imageInsideFrame)
         // 画像の前処理を実行
-        images = preprocessor.preprocess()
+        images = ImagePreprocessor.preprocess(image: getImageInsideFrame())
     } // loadSudoku ここまで
 
     // 枠内の画像を取得するメソッド

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -39,6 +39,7 @@ final class ScanSudokuViewModel {
         let imageInsideFrame = getImageInsideFrame()
         // ImagePreprocessorのインスタンスを生成
         let preprocessor = ImagePreprocessor(image: imageInsideFrame)
+        // 画像の前処理を実行
         images = preprocessor.preprocess()
     } // loadSudoku ここまで
 

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -54,4 +54,12 @@ final class ScanSudokuViewModel {
         // 取得した画像を保持
         return image
     } // getImageInsideFrame ここまで
+    
+    // プロパティの状態を初期値に戻すメソッド
+    func initializeProperties() {
+        selectedPhoto = nil
+        image = nil
+        frameRect = .zero
+        images.removeAll()
+    } // initializeProperties ここまで
 } // ScanSudokuViewModel ここまで

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -16,8 +16,8 @@ final class ScanSudokuViewModel {
     var image: UIImage? = nil
     // フレームの座標とサイズの情報を保持する変数
     var frameRect: CGRect = .zero
-    // 枠から切り抜いたImageを保持する変数
-    var imageInsideFrame: UIImage? = nil
+    // 各セルのImageを保持する配列
+    var images: [UIImage] = []
     
     @MainActor
     // PhotosPickerItemをUIImageに変換
@@ -33,15 +33,24 @@ final class ScanSudokuViewModel {
         } // if let ここまで
     } // getUIImage ここまで
     
+    // 画像から数独を読み込むメソッド
+    func loadSudoku() {
+        // 枠内の画像を取得
+        let imageInsideFrame = getImageInsideFrame()
+        // ImagePreprocessorのインスタンスを生成
+        let preprocessor = ImagePreprocessor(image: imageInsideFrame)
+        images = preprocessor.preprocess()
+    } // loadSudoku ここまで
+
     // 枠内の画像を取得するメソッド
-    func getImageInsideFrame() {
+    private func getImageInsideFrame() -> UIImage {
         // アプリケーションの最初のシーンを取得し、それがUIWindowSceneであることを確認
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return UIImage() }
         // 取得したウィンドウシーンから、最初のウィンドウを取得
-        guard let mainWindow = windowScene.windows.first else { return }
+        guard let mainWindow = windowScene.windows.first else { return UIImage() }
         // ウィンドウのルートビューコントローラーのビューから、指定された枠内の画像を取得
-        guard let image = mainWindow.rootViewController?.view.getImage(rect: frameRect) else { return }
+        guard let image = mainWindow.rootViewController?.view.getImage(rect: frameRect) else { return UIImage() }
         // 取得した画像を保持
-        imageInsideFrame = image
+        return image
     } // getImageInsideFrame ここまで
 } // ScanSudokuViewModel ここまで

--- a/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
+++ b/SudokuSolver/ViewModel/ScanSudokuViewModel.swift
@@ -31,8 +31,8 @@ final class ScanSudokuViewModel {
         return image
     } // getImageInsideFrame ここまで
     
-    @MainActor
     // PhotosPickerItemをUIImageに変換
+    @MainActor
     func getUIImage() async {
         if let selectedPhoto {
             do {


### PR DESCRIPTION
<!-- Issueのテンプレートです。入力できるところを埋めてください。 -->
<!-- 記入しない項目は特になしと記入してください。。 -->

<!-- 関連Isuueを記載してください。close #の後にIssue番号を記載すると連携でき、プルリクのマージ時にIssueもcloseします。 -->
## 関連Isuue番号
close #35

<!-- 追加、または修正する機能の概要を記述してください。 -->
## 追加・変更の概要
画像から数独を読み込むための前処理の機能

<!-- なぜこの追加・変更が必要なのか目的を記述してください。 -->
## 変更の目的
Visionフレームワークによる文字認識を用いて、画像から数独を読み取ります。
そのため、まず初めに、画像から数独を読み込むための前処理をう必要があります。

<!-- 進捗状況をチェックボックスで管理してください。 -->
## タスクの進捗状況
- [x] 画像から数独の81個の各セルの画像を取得（この時、枠を含まないように注意）
- [x] 画像を28x28ピクセルにリサイズ
- [x] 画像をグレースケールに変換
- [x] 画像を白黒反転
- [x] リストに表示して確認

<!-- UIのキャプチャ、APIのリクエスト/レスポンス等、変更内容を明確に記述してください。 -->
## 変更内容
- 画像の前処理に関するメソッドを集めたクラスであるImagePreprocessorを作成しました。
- LoadSudokuボタンが押された時にImagePreprocessor.preprocessメソッドを使用して、枠の中の画像を前処理してリストに表示するようにしました。

<!-- 影響範囲を予め明確に想定して記述してください。 -->
## 影響範囲
- ImagePreprocessor
- ScanSudokuView
- ScanSudokuViewModel

<!-- 追加・変更した機能の操作方法を記述してください。キャプチャや動画を添付してください。 -->
## 操作方法
1. フォトライブラリーもしくは写真機能により、画像を取得してください。
2. LoadSudokuボタンを押して、枠の中の画像が前処理され、リストに表示されることを確認してください。



前処理は以下の通り
1. 画像から数独の81個の各セルの画像を取得（この時、枠を含まないように注意）
2. 画像を28x28ピクセルにリサイズ
3. 画像をグレースケールに変換
4. 画像を白黒反転

<!-- テストしたことをリストアップしてください。 -->
## テストしたこと
上記の内容を確認しました。
<!-- 相談事項や、重点的にレビューしてほしいところを記述してください。 -->
## 相談事項
特になし。